### PR TITLE
feat: support LINEAR_API_KEY environment variable

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,14 @@ pub fn set_api_key(key: &str) -> Result<()> {
 }
 
 pub fn get_api_key() -> Result<String> {
+    // Check for LINEAR_API_KEY environment variable first
+    if let Ok(api_key) = std::env::var("LINEAR_API_KEY") {
+        if !api_key.is_empty() {
+            return Ok(api_key);
+        }
+    }
+
+    // Fall back to config file
     let config = load_config()?;
     let current = config
         .current


### PR DESCRIPTION
## Summary

This PR adds support for the `LINEAR_API_KEY` environment variable, allowing users to override the configured API key on a per-session basis.

## Changes

- Modified `get_api_key()` in `src/config.rs` to check for `LINEAR_API_KEY` env var first
- Falls back to existing config file behavior if env var is not set or empty

## Use Cases

- **CI/CD pipelines**: Set API key via environment without modifying config files
- **Multi-workspace scripts**: Run commands against different workspaces without switching
- **Agent processes**: Spawn isolated processes with their own API key context
- **Security**: Avoid storing API keys in config files on shared systems

## Example Usage

```bash
# Override API key for a single command
LINEAR_API_KEY=lin_api_xxx linear-cli issues list

# Set for entire shell session
export LINEAR_API_KEY=lin_api_xxx
linear-cli issues list
linear-cli comments create --body "Hello" ISSUE-123
```

## Backward Compatibility

Fully backward compatible - existing config-based authentication continues to work unchanged when the environment variable is not set.