### PR TITLE
Remove shared caches from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,6 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.target }}
-
       - name: Install cross
         if: matrix.use_cross
         run: cargo install cross --git https://github.com/cross-rs/cross
@@ -101,9 +96,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
 
       - name: Publish to crates.io
         run: cargo publish --allow-dirty


### PR DESCRIPTION
## Summary
- remove Rust cache steps from the release and crates.io publish jobs
- keep release and publish behavior intact while avoiding shared cache reuse in privileged publish paths

## Why
Recent supply-chain incidents, including the TanStack compromise, are a reminder that privileged PR/release/publish workflows should minimize shared mutable state. Caches can cross trust boundaries or preserve attacker-influenced artifacts longer than intended, and `pull_request_target` runs with elevated context compared with normal PR workflows.

## Validation
- parsed the touched workflow YAML successfully after the edit
- confirmed the touched workflows no longer reference `pull_request_target` or shared cache directives
