### PR TITLE
Fix --all-features build break and deflake priority colored-output tests

### DIFF
--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "secure-storage")]
+use anyhow::Context;
 use anyhow::Result;
 use clap::Subcommand;
 use dialoguer::{Confirm, Password};

--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -2294,12 +2294,15 @@ mod tests {
 
     #[test]
     fn test_format_history_priority_change() {
+        // `format_history_entry` calls `sanitize_terminal_text` on its
+        // output (see end of the function), so it never returns ANSI
+        // escapes — compare against a plain literal. (Coloring of the
+        // priority label itself is covered by priority::tests.)
         let entry = serde_json::json!({
             "fromPriority": 3.0,
             "toPriority": 1.0
         });
-        let expected = format!("Priority: Normal → {}", "Urgent".red());
-        assert_eq!(format_history_entry(&entry), expected);
+        assert_eq!(format_history_entry(&entry), "Priority: Normal → Urgent");
     }
 
     #[test]

--- a/src/priority.rs
+++ b/src/priority.rs
@@ -15,38 +15,53 @@ pub fn priority_to_string(priority: Option<i64>) -> String {
 mod tests {
     use super::*;
 
+    // Tests that compare colored output force the colored crate's override
+    // to `true`. Otherwise the production call and the test's expected value
+    // each consult `should_colorize()` independently, and colored 2.x runs a
+    // fresh `atty::is(Stdout)` check on every call — under parallel
+    // `cargo test` the two consecutive checks can return different answers
+    // on the same thread, so one side emits ANSI escapes and the other does
+    // not. Forcing override(true) bypasses the racy TTY check.
+
     #[test]
     fn test_priority_none() {
+        colored::control::set_override(true);
         assert_eq!(priority_to_string(None), "-");
     }
 
     #[test]
     fn test_priority_zero() {
+        colored::control::set_override(true);
         assert_eq!(priority_to_string(Some(0)), "-");
     }
 
     #[test]
     fn test_priority_urgent() {
+        colored::control::set_override(true);
         assert_eq!(priority_to_string(Some(1)), "Urgent".red().to_string());
     }
 
     #[test]
     fn test_priority_high() {
+        colored::control::set_override(true);
         assert_eq!(priority_to_string(Some(2)), "High".yellow().to_string());
     }
 
     #[test]
     fn test_priority_normal() {
+        colored::control::set_override(true);
         assert_eq!(priority_to_string(Some(3)), "Normal");
     }
 
     #[test]
     fn test_priority_low() {
+        colored::control::set_override(true);
         assert_eq!(priority_to_string(Some(4)), "Low".dimmed().to_string());
     }
 
     #[test]
     fn test_priority_invalid() {
+        colored::control::set_override(true);
         assert_eq!(priority_to_string(Some(5)), "-");
         assert_eq!(priority_to_string(Some(-1)), "-");
     }


### PR DESCRIPTION
## Summary

Two fixes for problems that surface when running `cargo test --all-features`:

1. **Build break in `src/commands/auth.rs`** — `auth.rs:545` calls `.context(...)` on a `Result` but `anyhow::Context` is not imported. The default-feature build is unaffected because that call is gated on `#[cfg(feature = "secure-storage")]`, so it only breaks `--features secure-storage` / `--all-features`. Downstream packagers (e.g. the AUR `linear-cli-finesssee` PKGBUILD) have been patching this in via `sed` in `prepare()`.

2. **Flaky tests asserting colored output.** Five tests built their expected value with `"Urgent".red()` / `"High".yellow()` / `"Low".dimmed()` and compared it to a value that also went through the `colored` crate. Both sides ultimately consult `colored::control::SHOULD_COLORIZE.should_colorize()`, which in colored 2.x runs a fresh `atty::is(Stdout)` check **on every call**. Under parallel `cargo test`, two consecutive `should_colorize()` calls on the same thread can return different answers (stdout state is shared across the test runner's threads), so one side emits ANSI escapes and the other doesn't, and the test fails with:

   ```
   left:  "Priority: Normal -> Urgent"
   right: "Priority: Normal -> \u{1b}[31mUrgent\u{1b}[0m"
   ```

   Reproduced reliably on Linux with the default `--test-threads`; passes when run in isolation.

## Fix details

The fix differs per test because the two affected modules have different intent:

- **`src/priority.rs` tests** call `priority_to_string` directly, which *does* return ANSI-coloured strings. The tests want to verify the colouring, so they now call `colored::control::set_override(true)` to bypass the racy TTY check. I applied it uniformly across the module (including the currently-plain branches) so a future change that adds styling to e.g. the `Normal` branch won't silently start flaking.

- **`src/commands/issues.rs::test_format_history_priority_change`** was wrong-headed: `format_history_entry` pipes its output through `sanitize_terminal_text` (issues.rs:972), so the function literally cannot return ANSI escapes. The original assertion happened to pass only when `colored` independently gave up on its own. The test now compares against a plain literal — what the function actually produces. Colouring of the priority label itself remains covered by `priority::tests`.

## Caveat: the `set_override` approach is not perfectly race-free

`colored::control::set_override` mutates a *process-global* `lazy_static` and uses two separate `AtomicBool::store`s with `Ordering::Relaxed`:

```rust
pub fn set_override(&self, override_colorize: bool) {
    self.has_manual_override.store(true, Ordering::Relaxed);
    self.manual_override.store(override_colorize, Ordering::Relaxed);
}
```

This means:

- The override leaks across test boundaries. Once any one of the touched tests runs, every later test in the same binary sees `should_colorize() = true`. I verified no other test in this crate makes color-bearing assertions (`.red()`/`.yellow()`/`.dimmed()` only appear in production code and the tests touched here), so this is benign today — but a future test that assumes auto-detect ("under `cargo test`, output is plain") would silently break.
- Between the two `store`s, a concurrent reader on another thread can observe `has_manual_override = true` while `manual_override` is still the old default `false`. With many parallel writers all setting `true` this converges quickly, but in principle it could reproduce the original flake class under sufficient contention.

If you'd like a bulletproof fix, two options:

1. Pull in `serial_test` (or a `Mutex<()>` in the test module) and serialize color-asserting tests, calling `unset_override()` at the end of each.
2. Refactor `priority_to_string` to take an explicit `colorize: bool` parameter (or split into a `priority_label` + `priority_color` pair) so tests pass a fixed value and never touch the global.

Happy to do either as a follow-up if you'd prefer — wanted to keep this PR small.

## Test plan

- [x] `cargo build --all-features` succeeds (previously failed with the missing `Context` import).
- [x] `cargo test --all-features` passes 305 unit + 197 integration tests, **stable across 5 consecutive runs**. Previously `commands::issues::tests::test_format_history_priority_change` would flake ~50% of runs and the priority colored-output tests would flake occasionally.
- [x] No production code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)