### PR TITLE
docs: add AI review smoke test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 ._*
 .DS_Store
 .clawpatch/
+.ai-review/
 
 # Claude Code local settings (not skills)
 .claude/settings.local.json

--- a/docs/ai-review-smoke.md
+++ b/docs/ai-review-smoke.md
@@ -1,0 +1,3 @@
+# AI Review Smoke Test
+
+This temporary document exists to verify the local AI review harness can post a managed GitHub PR comment.


### PR DESCRIPTION
Smoke PR to verify the local ai-reviewer GitHub comment path. This PR can be closed after confirming the managed AI review comment updates correctly.