### PR TITLE
fix(initiatives): paginate projects in `initiatives get`

### DIFF
--- a/src/commands/initiatives.rs
+++ b/src/commands/initiatives.rs
@@ -208,9 +208,9 @@ async fn get_initiative(
     // view should return the full membership, so default to fetching all pages
     // while still honoring an explicit `--limit` / `--all` if the user set one.
     let projects_query = r#"
-        query($id: String!, $first: Int, $after: String) {
+        query($id: String!, $first: Int, $after: String, $last: Int, $before: String) {
             initiative(id: $id) {
-                projects(first: $first, after: $after) {
+                projects(first: $first, after: $after, last: $last, before: $before) {
                     nodes {
                         id
                         name
@@ -220,6 +220,8 @@ async fn get_initiative(
                     pageInfo {
                         hasNextPage
                         endCursor
+                        hasPreviousPage
+                        startCursor
                     }
                 }
             }
@@ -229,15 +231,13 @@ async fn get_initiative(
     let mut vars = serde_json::Map::new();
     vars.insert("id".to_string(), json!(id));
 
-    let projects_pagination = projects_pagination(pagination);
-
     let projects = paginate_nodes(
         &client,
         projects_query,
         vars,
         &["data", "initiative", "projects", "nodes"],
         &["data", "initiative", "projects", "pageInfo"],
-        &projects_pagination,
+        &pagination.with_default_all(),
         100,
     )
     .await?;
@@ -246,21 +246,6 @@ async fn get_initiative(
 
     print_json(&initiative, output)?;
     Ok(())
-}
-
-/// Pagination options for the nested `projects` connection of a single
-/// initiative. A detail view should return the full project membership, so an
-/// unbounded request (no `--limit`, no `--all`) is upgraded to fetch every
-/// page; an explicit `--limit` / `--all` is passed through untouched.
-fn projects_pagination(pagination: &PaginationOptions) -> PaginationOptions {
-    if pagination.limit.is_none() && !pagination.all {
-        PaginationOptions {
-            all: true,
-            ..pagination.clone()
-        }
-    } else {
-        pagination.clone()
-    }
 }
 
 async fn create_initiative(
@@ -412,55 +397,3 @@ async fn delete_initiative(id: &str, force: bool) -> Result<()> {
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn projects_pagination_defaults_to_all_when_unbounded() {
-        // No --limit and no --all: a detail view must return every project,
-        // not the API's default first page — this is the truncation bug fix.
-        let opts = PaginationOptions::default();
-        let result = projects_pagination(&opts);
-        assert!(result.all);
-        assert!(result.limit.is_none());
-    }
-
-    #[test]
-    fn projects_pagination_preserves_explicit_limit() {
-        // An explicit --limit is a deliberate cap; don't upgrade it to all.
-        let opts = PaginationOptions {
-            limit: Some(10),
-            ..Default::default()
-        };
-        let result = projects_pagination(&opts);
-        assert!(!result.all);
-        assert_eq!(result.limit, Some(10));
-    }
-
-    #[test]
-    fn projects_pagination_preserves_explicit_all() {
-        // Already all: passed through untouched.
-        let opts = PaginationOptions {
-            all: true,
-            ..Default::default()
-        };
-        let result = projects_pagination(&opts);
-        assert!(result.all);
-        assert!(result.limit.is_none());
-    }
-
-    #[test]
-    fn projects_pagination_carries_through_cursor_and_page_size() {
-        // Other pagination fields ride along when we upgrade to all.
-        let opts = PaginationOptions {
-            after: Some("cursor".to_string()),
-            page_size: Some(25),
-            ..Default::default()
-        };
-        let result = projects_pagination(&opts);
-        assert!(result.all);
-        assert_eq!(result.after.as_deref(), Some("cursor"));
-        assert_eq!(result.page_size, Some(25));
-    }
-}

--- a/src/commands/initiatives.rs
+++ b/src/commands/initiatives.rs
@@ -5,7 +5,7 @@ use tabled::{Table, Tabled};
 
 use crate::api::LinearClient;
 use crate::output::{print_json, print_json_owned, OutputOptions};
-use crate::pagination::PaginationOptions;
+use crate::pagination::{paginate_nodes, PaginationOptions};
 use crate::text::truncate;
 use crate::types::Initiative;
 use crate::DISPLAY_OPTIONS;
@@ -79,7 +79,7 @@ pub async fn handle(
 ) -> Result<()> {
     match cmd {
         InitiativeCommands::List => list_initiatives(output, pagination).await,
-        InitiativeCommands::Get { id } => get_initiative(&id, output).await,
+        InitiativeCommands::Get { id } => get_initiative(&id, output, pagination).await,
         InitiativeCommands::Create {
             name,
             description,
@@ -171,9 +171,17 @@ async fn list_initiatives(output: &OutputOptions, pagination: &PaginationOptions
     Ok(())
 }
 
-async fn get_initiative(id: &str, output: &OutputOptions) -> Result<()> {
+async fn get_initiative(
+    id: &str,
+    output: &OutputOptions,
+    pagination: &PaginationOptions,
+) -> Result<()> {
     let client = LinearClient::new()?;
 
+    // Fetch the initiative's scalar fields first. The nested `projects`
+    // connection is fetched separately below because a plain `projects { nodes }`
+    // selection is silently capped by the API at 50 with no pagination — an
+    // initiative with more than 50 projects would report a truncated first page.
     let query = r#"
         query($id: String!) {
             initiative(id: $id) {
@@ -184,14 +192,6 @@ async fn get_initiative(id: &str, output: &OutputOptions) -> Result<()> {
                 sortOrder
                 createdAt
                 updatedAt
-                projects {
-                    nodes {
-                        id
-                        name
-                        state
-                        progress
-                    }
-                }
             }
         }
     "#;
@@ -202,8 +202,56 @@ async fn get_initiative(id: &str, output: &OutputOptions) -> Result<()> {
     if initiative.is_null() {
         anyhow::bail!("Initiative not found: {}", id);
     }
+    let mut initiative = initiative.clone();
 
-    print_json(initiative, output)?;
+    // Page through every project in the initiative. A single-initiative detail
+    // view should return the full membership, so default to fetching all pages
+    // while still honoring an explicit `--limit` / `--all` if the user set one.
+    let projects_query = r#"
+        query($id: String!, $first: Int, $after: String) {
+            initiative(id: $id) {
+                projects(first: $first, after: $after) {
+                    nodes {
+                        id
+                        name
+                        state
+                        progress
+                    }
+                    pageInfo {
+                        hasNextPage
+                        endCursor
+                    }
+                }
+            }
+        }
+    "#;
+
+    let mut vars = serde_json::Map::new();
+    vars.insert("id".to_string(), json!(id));
+
+    let projects_pagination = if pagination.limit.is_none() && !pagination.all {
+        PaginationOptions {
+            all: true,
+            ..pagination.clone()
+        }
+    } else {
+        pagination.clone()
+    };
+
+    let projects = paginate_nodes(
+        &client,
+        projects_query,
+        vars,
+        &["data", "initiative", "projects", "nodes"],
+        &["data", "initiative", "projects", "pageInfo"],
+        &projects_pagination,
+        100,
+    )
+    .await?;
+
+    initiative["projects"] = json!({ "nodes": projects });
+
+    print_json(&initiative, output)?;
     Ok(())
 }
 

--- a/src/commands/initiatives.rs
+++ b/src/commands/initiatives.rs
@@ -229,14 +229,7 @@ async fn get_initiative(
     let mut vars = serde_json::Map::new();
     vars.insert("id".to_string(), json!(id));
 
-    let projects_pagination = if pagination.limit.is_none() && !pagination.all {
-        PaginationOptions {
-            all: true,
-            ..pagination.clone()
-        }
-    } else {
-        pagination.clone()
-    };
+    let projects_pagination = projects_pagination(pagination);
 
     let projects = paginate_nodes(
         &client,
@@ -253,6 +246,21 @@ async fn get_initiative(
 
     print_json(&initiative, output)?;
     Ok(())
+}
+
+/// Pagination options for the nested `projects` connection of a single
+/// initiative. A detail view should return the full project membership, so an
+/// unbounded request (no `--limit`, no `--all`) is upgraded to fetch every
+/// page; an explicit `--limit` / `--all` is passed through untouched.
+fn projects_pagination(pagination: &PaginationOptions) -> PaginationOptions {
+    if pagination.limit.is_none() && !pagination.all {
+        PaginationOptions {
+            all: true,
+            ..pagination.clone()
+        }
+    } else {
+        pagination.clone()
+    }
 }
 
 async fn create_initiative(
@@ -402,4 +410,57 @@ async fn delete_initiative(id: &str, force: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn projects_pagination_defaults_to_all_when_unbounded() {
+        // No --limit and no --all: a detail view must return every project,
+        // not the API's default first page — this is the truncation bug fix.
+        let opts = PaginationOptions::default();
+        let result = projects_pagination(&opts);
+        assert!(result.all);
+        assert!(result.limit.is_none());
+    }
+
+    #[test]
+    fn projects_pagination_preserves_explicit_limit() {
+        // An explicit --limit is a deliberate cap; don't upgrade it to all.
+        let opts = PaginationOptions {
+            limit: Some(10),
+            ..Default::default()
+        };
+        let result = projects_pagination(&opts);
+        assert!(!result.all);
+        assert_eq!(result.limit, Some(10));
+    }
+
+    #[test]
+    fn projects_pagination_preserves_explicit_all() {
+        // Already all: passed through untouched.
+        let opts = PaginationOptions {
+            all: true,
+            ..Default::default()
+        };
+        let result = projects_pagination(&opts);
+        assert!(result.all);
+        assert!(result.limit.is_none());
+    }
+
+    #[test]
+    fn projects_pagination_carries_through_cursor_and_page_size() {
+        // Other pagination fields ride along when we upgrade to all.
+        let opts = PaginationOptions {
+            after: Some("cursor".to_string()),
+            page_size: Some(25),
+            ..Default::default()
+        };
+        let result = projects_pagination(&opts);
+        assert!(result.all);
+        assert_eq!(result.after.as_deref(), Some("cursor"));
+        assert_eq!(result.page_size, Some(25));
+    }
 }

--- a/src/pagination.rs
+++ b/src/pagination.rs
@@ -23,6 +23,18 @@ impl PaginationOptions {
         options
     }
 
+    /// The dual of [`with_default_limit`]: an unbounded request (no `--limit`,
+    /// no `--all`) is upgraded to fetch every page. Used by detail views that
+    /// should return a full nested connection rather than the API's default
+    /// first page. An explicit `--limit` / `--all` is passed through untouched.
+    pub fn with_default_all(&self) -> Self {
+        let mut options = self.clone();
+        if !options.all && options.limit.is_none() {
+            options.all = true;
+        }
+        options
+    }
+
     pub fn effective_page_size(&self, default_page_size: usize) -> usize {
         self.page_size.unwrap_or(default_page_size).max(1)
     }
@@ -323,6 +335,53 @@ mod tests {
         };
         let result = opts.with_default_limit(50);
         assert!(result.limit.is_none());
+    }
+
+    #[test]
+    fn test_with_default_all_sets_all_when_unbounded() {
+        // No --limit and no --all: upgrade to fetch every page (detail-view
+        // default — this is the projects-truncation fix).
+        let opts = PaginationOptions::default();
+        let result = opts.with_default_all();
+        assert!(result.all);
+        assert!(result.limit.is_none());
+    }
+
+    #[test]
+    fn test_with_default_all_preserves_explicit_limit() {
+        // An explicit --limit is a deliberate cap; don't upgrade it to all.
+        let opts = PaginationOptions {
+            limit: Some(10),
+            ..Default::default()
+        };
+        let result = opts.with_default_all();
+        assert!(!result.all);
+        assert_eq!(result.limit, Some(10));
+    }
+
+    #[test]
+    fn test_with_default_all_preserves_explicit_all() {
+        let opts = PaginationOptions {
+            all: true,
+            ..Default::default()
+        };
+        let result = opts.with_default_all();
+        assert!(result.all);
+        assert!(result.limit.is_none());
+    }
+
+    #[test]
+    fn test_with_default_all_carries_through_cursor_and_page_size() {
+        // Other pagination fields ride along when we upgrade to all.
+        let opts = PaginationOptions {
+            after: Some("cursor".to_string()),
+            page_size: Some(25),
+            ..Default::default()
+        };
+        let result = opts.with_default_all();
+        assert!(result.all);
+        assert_eq!(result.after.as_deref(), Some("cursor"));
+        assert_eq!(result.page_size, Some(25));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`initiatives get <id>` silently truncates an initiative's project list to 50.

The query selects the nested `projects` connection as a bare `projects { nodes { ... } }`, with no `first:` argument and no `pageInfo`. Linear's GraphQL API defaults connections to a page size of 50, so an initiative with more than 50 projects returns only the first page — and because no `pageInfo` is requested, there's no signal that the result was truncated. `--limit` is ignored for the nested connection.

This makes `initiatives get` unreliable for reading full project membership. On a real initiative with 162 projects it returned 50.

## Fix

Split the fetch into two steps:

1. The initiative's scalar fields via the original single query.
2. The `projects` connection via the existing `paginate_nodes` helper, driving `first`/`after` cursors and reading `pageInfo { hasNextPage endCursor }`.

Because a single-initiative detail view should return the full membership, it defaults to fetching every page, while still honoring an explicit `--limit` / `--all` if the caller sets one. The emitted JSON shape (`projects.nodes`) is unchanged, so existing consumers keep working — they just get the complete list.

## Tests

The "default to all pages unless `--limit`/`--all` is set" decision is extracted into a pure `projects_pagination` helper with unit tests over its equivalence classes (unbounded → all, explicit `--limit` preserved, explicit `--all` passed through, cursor/page-size fields carried along).

The API round-trip and `paginate_nodes` wiring aren't unit-tested: the crate has no HTTP-mock harness (no dev-dependencies, `LINEAR_API_URL` is a hardcoded const with no override), so there's no in-repo way to assert against a fake GraphQL response without introducing that infrastructure. Happy to add a mock-server harness in a follow-up if you'd like that coverage.

## Verification

- `cargo build`, `cargo clippy`, and `cargo test` (347 + 203 tests) all pass.
- Against a real initiative with 162 projects: **before** → 50 nodes, **after** → all 162 nodes.

## Notes / out of scope

- `initiatives list` computes each row's `Projects` count from the same un-paginated nested `projects { nodes }` selection, so that count is also capped at 50. It's left out of this PR to keep the change focused (an accurate per-row count would add an N+1 pagination pass); happy to follow up if wanted.