### PR TITLE
fix(auth): fall back to the API key when an OAuth refresh fails

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Error, Result};
 use futures::StreamExt;
 use reqwest::header::HeaderMap;
 use reqwest::redirect::Policy;
@@ -645,6 +645,31 @@ impl AuthState {
     }
 }
 
+/// Pick the auth to continue with after an OAuth refresh attempt failed.
+///
+/// A refresh token can be expired or revoked, in which case the cached grant is
+/// dead and cannot be revived without an interactive `auth oauth` flow. If an API
+/// key is configured, the CLI can still authenticate, so a dead grant must not be
+/// allowed to fail the command — that is what makes the CLI unusable in
+/// non-interactive environments (CI, containers, agents), where `LINEAR_API_KEY`
+/// is set precisely because no browser is available.
+fn auth_after_failed_refresh(api_key: Option<String>, refresh_error: Error) -> Result<AuthState> {
+    match api_key {
+        Some(key) if !key.trim().is_empty() => {
+            eprintln!(
+                "Warning: OAuth token refresh failed ({}); falling back to API key authentication.",
+                refresh_error
+            );
+            Ok(AuthState::ApiKey(key))
+        }
+        _ => Err(refresh_error.context(
+            "OAuth token refresh failed and no API key is configured. \
+             Re-authenticate with `linear-cli auth oauth`, or set LINEAR_API_KEY / run \
+             `linear-cli auth login --key <key>` for non-interactive use.",
+        )),
+    }
+}
+
 #[derive(Clone)]
 pub struct LinearClient {
     client: Client,
@@ -847,7 +872,18 @@ impl LinearClient {
                     .as_ref()
                     .context("OAuth token expired but no refresh token available")?;
 
-                let new_tokens = crate::oauth::refresh_tokens(client_id, refresh_token).await?;
+                let new_tokens = match crate::oauth::refresh_tokens(client_id, refresh_token).await
+                {
+                    Ok(tokens) => tokens,
+                    Err(e) => {
+                        // A cached grant that can no longer be refreshed must not mask a
+                        // usable API key (see `auth_after_failed_refresh`).
+                        let fallback = auth_after_failed_refresh(config::get_api_key().ok(), e)?;
+                        let header = fallback.auth_header();
+                        *auth = fallback;
+                        return Ok(header);
+                    }
+                };
 
                 // Persist the new tokens
                 let scopes = if let Ok(Some(existing)) = config::get_oauth_metadata(profile) {
@@ -1000,6 +1036,49 @@ mod tests {
         assert!(
             state.needs_refresh(),
             "OAuth with expired token and refresh token should need refresh"
+        );
+    }
+
+    #[test]
+    fn test_auth_after_failed_refresh_falls_back_to_api_key() {
+        let state = auth_after_failed_refresh(
+            Some("lin_api_key123".to_string()),
+            anyhow::anyhow!("Refresh token expired"),
+        )
+        .expect("a configured API key should be used when the refresh fails");
+
+        assert!(matches!(state, AuthState::ApiKey(_)));
+        assert_eq!(state.auth_header(), "lin_api_key123");
+        assert!(
+            !state.needs_refresh(),
+            "the fallback must not try to refresh again"
+        );
+    }
+
+    #[test]
+    fn test_auth_after_failed_refresh_without_api_key_reports_original_error() {
+        let err = auth_after_failed_refresh(None, anyhow::anyhow!("Refresh token expired"))
+            .expect_err("without an API key there is no way to authenticate");
+
+        let chain = format!("{:#}", err);
+        assert!(
+            chain.contains("Refresh token expired"),
+            "the underlying refresh error must survive: {chain}"
+        );
+        assert!(
+            chain.contains("LINEAR_API_KEY"),
+            "the message should point at the non-interactive fix: {chain}"
+        );
+    }
+
+    #[test]
+    fn test_auth_after_failed_refresh_ignores_blank_api_key() {
+        let result =
+            auth_after_failed_refresh(Some("   ".to_string()), anyhow::anyhow!("Refresh failed"));
+
+        assert!(
+            result.is_err(),
+            "a blank API key is not credentials and must not be used as a fallback"
         );
     }
 


### PR DESCRIPTION
## Problem

A cached OAuth grant whose refresh token has expired (or been revoked) makes every command fail, even when a valid `LINEAR_API_KEY` is present:

```
$ linear-cli issues get ABC-123
Error: Token refresh failed (HTTP 400 Bad Request): {"error":"invalid_request","error_description":"Refresh token expired"}
```

`resolve_auth` selects OAuth whenever a refresh token exists — expiry isn't considered, since a refresh is assumed to fix it — and `ensure_fresh_auth` then propagates the refresh error with `?`. There is no path back to the API key at that point, so a dead grant masks working credentials.

This bites hardest exactly where the API key is the intended credential: CI, containers, and agent sessions, where no browser is available to re-run `auth oauth`. Today the only workaround is hand-editing or deleting `config.toml`.

## Change

When the refresh call fails, continue with a configured API key if there is one, warning on stderr so the stale grant stays visible:

```
$ linear-cli issues get ABC-123
Warning: OAuth token refresh failed (Token refresh failed (HTTP 400 Bad Request): {...}); falling back to API key authentication.
ABC-123 Some issue title
```

With no key to fall back to, the original refresh error still surfaces, now with a message naming both recovery paths (`auth oauth`, or `LINEAR_API_KEY` / `auth login --key` for non-interactive use). A blank key isn't treated as credentials.

Auth precedence is otherwise unchanged: a healthy OAuth grant still wins over an API key.

## Testing

- 3 unit tests on the new `auth_after_failed_refresh` seam (falls back; preserves the underlying error when there's no key; rejects a blank key).
- Full suite green: 553 tests.
- `cargo fmt` clean; `cargo clippy --all-targets` adds no new warnings.
- Verified end to end against a genuinely expired grant: `0.3.26` errors out, this build warns and completes the request.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nesszer/codesmith/linear-cli/pr/44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788545104&installation_model_id=427695&pr_number=44&repository=nesszer%2Flinear-cli&return_to=https%3A%2F%2Fgithub.com%2Fnesszer%2Flinear-cli%2Fpull%2F44&signature=57d54322a68104da208dc875ad6e705f63d2c157bcebd0a3f0acbb008da32b67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->